### PR TITLE
Add kotlin to codebase

### DIFF
--- a/lcopy.d/kotlin.lcopy
+++ b/lcopy.d/kotlin.lcopy
@@ -1,0 +1,3 @@
+REPO=https://github.com/JetBrains/kotlin.git
+ALIGNMENT=v1.4.21
+LANGUAGES=Kotlin


### PR DESCRIPTION
Follow up from https://github.com/universal-ctags/ctags/pull/2769. After some research it seems that Kotlin itself is still the biggest opensource project written in Kotlin.